### PR TITLE
Poller cleanup

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -16,7 +16,7 @@ pub async fn start(pool: &PgPool) -> Result<(), sqlx::Error> {
     let mut poller = Poller::new(POLL_INTERVAL, pool.clone()).await;
     let notifier = Arc::new(Mutex::new(Notifier::new(pool.clone()).await));
     let poll_task_handler = tokio::spawn(async move {
-        poller.poll().await;
+        poller.run().await;
     });
 
     let notify_task_handler = tokio::spawn(async move {

--- a/src/poller/mod.rs
+++ b/src/poller/mod.rs
@@ -7,16 +7,25 @@ use tokio::time::interval;
 
 /// Responsible for polling musicbrainz data for edit_notes and edit_data
 pub struct Poller {
+    /// Time between polls, in seconds
     poll_interval: u64,
+
+    /// The database pool
     pool: sqlx::PgPool,
+
+    /// The start id of the note poller
     edit_note_start_idx: i32,
+
+    /// The start if of the data poller
     edit_data_start_idx: i32,
 }
 
 impl Poller {
     pub async fn new(poll_interval: u64, pool: sqlx::PgPool) -> Poller {
+        // Fetch the start ids for the poller from the DB
         let (edit_data_start_idx, edit_note_start_idx) =
             get_edit_data_and_note_start_id(&pool).await;
+
         Poller {
             poll_interval,
             pool,
@@ -25,24 +34,28 @@ impl Poller {
         }
     }
 
-    /// Polls the `edit_data` and `edit_note` tables continuously
-    pub async fn poll(&mut self) {
+    /// This function is the main loop of the poller. Each loop polls the `edit_data` and `edit_note` tables for new changes
+    pub async fn run(&mut self) {
         let mut interval = interval(Duration::from_secs(self.poll_interval));
         loop {
             interval.tick().await;
-            match looper::poll_db(
+
+            let poll_future = looper::poll_db(
                 &self.pool,
                 self.edit_data_start_idx,
                 self.edit_note_start_idx,
-            )
-            .await
-            {
+            );
+
+            match poll_future.await {
                 Ok((edit_data_id, edit_note_id)) => {
-                    if edit_data_id.is_some() {
-                        self.edit_data_start_idx = edit_data_id.unwrap();
+                    // Set the next data's id
+                    if let Some(edit_data_id) = edit_data_id {
+                        self.edit_data_start_idx = edit_data_id;
                     }
-                    if edit_note_id.is_some() {
-                        self.edit_note_start_idx = edit_note_id.unwrap();
+
+                    // Set the next note's id
+                    if let Some(edit_note_id) = edit_note_id {
+                        self.edit_data_start_idx = edit_note_id;
                     }
                 }
                 Err(e) => {


### PR DESCRIPTION
I found some more area to clarify.

I refactored the `Poller` class to add a lot more comments, as well as splitting the unreadable match statement.

For the actual poll, I split both edit data polling and note data polling. This prevent weaving two different flows in the same function, and separate concerns.

I would also put the functions in the `looper` module into the `Poller` class directly, but I'm not sure if it is intentionally separated.